### PR TITLE
Fix: Avoids publishing waypoints if waypoint_tree is empty

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -51,7 +51,7 @@ class WaypointUpdater(object):
     def loop(self):
 	rate = rospy.Rate(50)
 	while not rospy.is_shutdown():
-		if self.pose and self.base_waypoints:
+		if self.pose and self.base_waypoints and self.waypoint_tree:
 			# Get closest waypoint
 			closest_waypoint_idx = self.get_closest_waypoint_idx()
 			self.publish_waypoints(closest_waypoint_idx)


### PR DESCRIPTION
I has having the following error when running your code in the simulator:

```
Traceback (most recent call last):
  File "/capstone/ros/src/waypoint_updater/waypoint_updater.py", line 130, in <module>
    WaypointUpdater()
  File "/capstone/ros/src/waypoint_updater/waypoint_updater.py", line 48, in __init__
    self.loop()
  File "/capstone/ros/src/waypoint_updater/waypoint_updater.py", line 56, in loop
    closest_waypoint_idx = self.get_closest_waypoint_idx()
  File "/capstone/ros/src/waypoint_updater/waypoint_updater.py", line 63, in get_closest_waypoint_idx
    closest_idx = self.waypoint_tree.query([x, y], 1)[1]
AttributeError: 'NoneType' object has no attribute 'query'
```

This pull requests aims to solve this problem, as it prevents the `waypoint_updater`node from publishing waypoints when `waypoint_tree`is empty/not initialized.